### PR TITLE
Improve type syntax error detection

### DIFF
--- a/Asm/binary.scm
+++ b/Asm/binary.scm
@@ -53,7 +53,6 @@
    (display n out-port))
 
 (define (write-type t op::output-port)
-   (tprint "write-type t=" t)
    (match-case t
       ((? valtype-symbol?)
        (write-byte (hashtable-get *valtype-symbols* t) op))

--- a/Asm/binary.scm
+++ b/Asm/binary.scm
@@ -53,6 +53,7 @@
    (display n out-port))
 
 (define (write-type t op::output-port)
+   (tprint "write-type t=" t)
    (match-case t
       ((? valtype-symbol?)
        (write-byte (hashtable-get *valtype-symbols* t) op))
@@ -63,10 +64,13 @@
       ((ref ?t)
        (write-byte #x64 op)
        (write-type t op))
-      ((or (? rectype?) (? deftype?)) (leb128-write-signed (cer t) op))
+      ((or (? rectype?) (? deftype?))
+       (leb128-write-signed (cer t) op))
       ((ref null ?t)
        (write-byte #x63 op)
-       (write-type t op))))
+       (write-type t op))
+      (else
+       (error "write-type" "Illegal type" t))))
 
 (define (write-comptype t op::output-port)
    (define (write-fieldtype t op::output-port)

--- a/Opt/CFG/node.scm
+++ b/Opt/CFG/node.scm
@@ -25,7 +25,7 @@
 
            ;; the last one is the default
            (class switch::jump
-              dsts::pair)
+              dsts::pair-nil)
 
            (class on-cast::jump
               rt-dst::pair

--- a/Opt/CFG/walk.scm
+++ b/Opt/CFG/walk.scm
@@ -335,13 +335,15 @@
            (br_on_cast
             (with-access::three-args (car l) (x y z)
                (with-access::labelidxp x (idx)
-                  (end-current-block (instantiate::on-cast
-                                      (dst-cast-fail
-                                       (build-node (cdr l) st st '()
-                                                   next labs))
-                                      (rt-src y)
-                                      (rt-dst z)
-                                      (dst-cast (list-ref labs idx)))))))
+		  (with-access::typep y ((ty type))
+		     (with-access::typep z ((tz type))
+			(end-current-block (instantiate::on-cast
+					      (dst-cast-fail
+						 (build-node (cdr l) st st '()
+						    next labs))
+					      (rt-src ty)
+					      (rt-dst tz)
+					      (dst-cast (list-ref labs idx)))))))))
 
            (else
             (let ((new-st (append (reverse outtype)

--- a/Opt/Const/walk.scm
+++ b/Opt/Const/walk.scm
@@ -16,7 +16,7 @@
    (eq? 'i32.const (-> i opcode)))
 
 (define (isa-if? i::instruction)
-   (isa? if-then i))
+   (isa? i if-then))
 
 (define-generic (const-fold-if! i::if-then x::i32p)
    (if (= 0 (-> x num))
@@ -26,8 +26,8 @@
 (define-method (const-fold-if! i::if-else x::i32p)
    (duplicate::block
       (if (= 0 (-> x num))
-          (with-access::sequence (-> i else) (body) body)
-          (with-access::sequence (-> i then) (body) body))))
+	  (-> i else)
+	  (-> i then))))
 
 (define-method (const-fold! i::sequence)
    (define (walk-list l::pair-nil)

--- a/Opt/TestBr/walk.scm
+++ b/Opt/TestBr/walk.scm
@@ -124,8 +124,9 @@
 
 (define-method (incr-labels! i::try_table threshold::long)
    (define (incr-labels-catch! c::catch-branch)
-     (if (>= (-> c label) threshold)
-       (set! (-> c label) (+fx 1 (-> c label)))))
+      (with-access::labelidxp (-> c label) (idx)
+	 (if (>=fx idx threshold)
+	     (set! idx (+fx 1 idx)))))
    (for-each incr-labels-catch! (-> i catches))
    (call-next-method))
 

--- a/Type/type.scm
+++ b/Type/type.scm
@@ -84,7 +84,8 @@
       ((or extern noextern) 'extern)
       ((or exn noexn) 'exn)
       ((? idx?) (ht-upperbound env (type-get env t)))
-      ((? deftype?) (ht-upperbound env (deftype-head t)))))
+      ((? deftype?) (ht-upperbound env (deftype-head t)))
+      (else (error "ht-upperbound" "Illegal type" t))))
 
 (define (rt-upperbound::pair env::env t)
    `(ref null ,(ht-upperbound env (reftype->heaptype t))))
@@ -94,7 +95,8 @@
       (i8 #l8)
       (i16 #l16)
       (i32 #l32)
-      (i64 #l64)))
+      (i64 #l64)
+      (else #l0)))
 
 ;; deftypes type x = (rec subtypes*).i are represented as epairs (deftype
 ;; subtypes* i)) with cer equal to x ; x = (rec i) are represented as (rec i)
@@ -115,7 +117,9 @@
            (final (?hd . ?-))
            (?- (?hd . ?-))
            ((?hd . ?-)))
-       hd)))
+       hd)
+      (else
+       (error "deftype-head" "Illegal type" t))))
 
 (define (nullable?::bool rt::pair)
    (eq? (cadr rt) 'null))

--- a/Val/instruction-types.sch
+++ b/Val/instruction-types.sch
@@ -480,15 +480,21 @@
   ; https://webassembly.github.io/spec/versions/core/WebAssembly-3.0-draft.pdf#subsubsection*.196
   (br_on_cast
    (,labelidx ,rt ,rt)
-   ,(lambda (env l::labelidxp rt1 rt2)
-       (multiple-value-bind (t* rt') (label-get-last-rest l)
-          (unless (reftype? rt')
-             (raise `(expected-reftype-label ,rt')))
-          (unless (<rt= env rt2 rt1)
-             (raise `(non-matching ,rt2 ,rt1)))
-          (unless (<rt= env rt2 rt')
-             (raise `(non-matching ,rt2 ,rt')))
-          `((,@t* ,rt1) (,@t* ,(rt-diff rt1 rt2))))))
+   ,(lambda (env l::labelidxp t1 t2)
+       (let ((rt1 (if (isa? t1 typep)
+		      (with-access::typep t1 (type) type)
+		      t1))
+	     (rt2 (if (isa? t2 typep)
+		      (with-access::typep t2 (type) type)
+		      t2)))
+	  (multiple-value-bind (t* rt') (label-get-last-rest l)
+	     (unless (reftype? rt')
+		(raise `(expected-reftype-label ,rt')))
+	     (unless (<rt= env rt2 rt1)
+		(raise `(non-matching ,rt2 ,rt1)))
+	     (unless (<rt= env rt2 rt')
+		(raise `(non-matching ,rt2 ,rt')))
+	     `((,@t* ,rt1) (,@t* ,(rt-diff rt1 rt2)))))))
 
   ; https://webassembly.github.io/spec/versions/core/WebAssembly-3.0-draft.pdf#subsubsection*.197
   (br_on_cast_fail

--- a/watib.scm
+++ b/watib.scm
@@ -20,6 +20,7 @@
 ;; their new index
 (define (merge-files l)
    (define (get-mfs f)
+      ;; (bigloo-string-encoding-set! 'wasm)
       (call-with-input-file f
          (lambda (ip)
             (match-case (read ip #t)


### PR DESCRIPTION
Better syntax error detection. 

The illegal type declarations `(type ident ident)`  were causing  watib crashes. This PR fixes that problem. These illegal types are now correctly detected and reported.